### PR TITLE
Add Approver Model with Scope-based Approval Permissions

### DIFF
--- a/backend/api/admin.py
+++ b/backend/api/admin.py
@@ -52,7 +52,7 @@ class WorkflowStepAdmin(admin.ModelAdmin):
         "approvals_required",
         "is_optional",
     )
-    list_filter = "workflow"
+    list_filter = ("workflow",)
     ordering = ("workflow", "step_number")
 
 

--- a/backend/api/admin.py
+++ b/backend/api/admin.py
@@ -1,6 +1,6 @@
 from django.contrib import admin
 from django.contrib.auth.admin import UserAdmin
-from .models import CustomUser, Unit, Approver
+from .models import CustomUser, Unit, Approver, Workflow, WorkflowStep
 
 
 class UnitAdmin(admin.ModelAdmin):
@@ -33,3 +33,27 @@ class ApproverAdmin(admin.ModelAdmin):
 
 
 admin.site.register(Approver, ApproverAdmin)
+
+
+class WorkflowAdmin(admin.ModelAdmin):
+    list_display = ("name", "form_type", "origin_unit", "is_active")
+    search_fields = ("name", "form_type", "origin_unit")
+
+
+admin.site.register(Workflow, WorkflowAdmin)
+
+
+class WorkflowStepAdmin(admin.ModelAdmin):
+    list_display = (
+        "workflow",
+        "step_number",
+        "role_required",
+        "approver_unit",
+        "approvals_required",
+        "is_optional",
+    )
+    list_filter = "workflow"
+    ordering = ("workflow", "step_number")
+
+
+admin.site.register(WorkflowStep, WorkflowStepAdmin)

--- a/backend/api/admin.py
+++ b/backend/api/admin.py
@@ -1,6 +1,6 @@
 from django.contrib import admin
 from django.contrib.auth.admin import UserAdmin
-from .models import CustomUser, Unit
+from .models import CustomUser, Unit, Approver
 
 
 class UnitAdmin(admin.ModelAdmin):
@@ -24,3 +24,12 @@ class CustomUserAdmin(UserAdmin):
 
 
 admin.site.register(CustomUser, CustomUserAdmin)
+
+
+class ApproverAdmin(admin.ModelAdmin):
+    list_display = ("user", "scope", "unit")
+    list_filter = ("scope", "unit")
+    search_fields = ("user__username", "user__email")
+
+
+admin.site.register(Approver, ApproverAdmin)

--- a/backend/api/models.py
+++ b/backend/api/models.py
@@ -38,6 +38,9 @@ class Form(models.Model):
     # JSON field to store JSON data
     data = JSONField(default=dict)  # Use JSONField for Django >= 3.1
 
+    # Matches form with a specific approval workflow
+    type = models.CharField(max_length=100, default="general")
+
     def __str__(self):
         return f"Form {self.id} - {self.status}"
 
@@ -108,3 +111,51 @@ class Delegation(models.Model):
     class Meta:
         verbose_name = "Delegator"
         verbose_name_plural = "Delegators"
+
+
+class Workflow(models.Model):
+    form_type = models.CharField(max_length=100)
+    origin_unit = models.ForeignKey(Unit, on_delete=models.CASCADE)
+    name = models.CharField(max_length=255)
+    is_active = models.BooleanField(default=True)
+
+    class Meta:
+        verbose_name = "Workflow"
+        verbose_name_plural = "Workflows"
+
+    def __str__(self):
+        return f"{self.name} ({self.form_type} from {self.origin_unit})"
+
+
+class WorkflowStep(models.Model):
+    workflow = models.ForeignKey(
+        Workflow, related_name="steps", on_delete=models.CASCADE
+    )
+    step_number = models.PositiveIntegerField()
+    role_required = models.CharField(max_length=100)  # e.g. dept-chair
+    approver_unit = models.ForeignKey(
+        Unit, null=True, blank=True, on_delete=models.SET_NULL
+    )
+    is_optional = models.BooleanField(default=False)
+    approvals_required = models.PositiveIntegerField(
+        default=1
+    )  # number of approvals needed
+
+    class Meta:
+        ordering = ["step_number"]
+
+    def __str__(self):
+        return f"{self.workflow.name} - Step {self.step_number}"
+
+
+class FormApprovalStep(models.Model):
+    form = models.ForeignKey(
+        Form, on_delete=models.CASCADE, related_name="approval_steps"
+    )
+    step_number = models.PositiveIntegerField()
+    approver = models.ForeignKey(CustomUser, on_delete=models.CASCADE)
+    is_completed = models.BooleanField(default=False)
+    approved_on = models.DateTimeField(null=True, blank=True)
+
+    class Meta:
+        ordering = ["step_number"]

--- a/backend/api/models.py
+++ b/backend/api/models.py
@@ -63,7 +63,9 @@ class Unit(models.Model):
 class Approver(models.Model):
     user = models.ForeignKey(CustomUser, on_delete=models.CASCADE)
     scope = models.CharField(
-        choices=[("unit", "Unit"), ("org", "Organization")], default="unit"
+        max_length=5,
+        choices=[("unit", "Unit"), ("org", "Organization")],
+        default="unit",
     )
     unit = models.ForeignKey(Unit, on_delete=models.CASCADE, null=True, blank=True)
 

--- a/backend/api/models.py
+++ b/backend/api/models.py
@@ -81,6 +81,10 @@ class Approver(models.Model):
                 "Organizational-level approvers should not be assigned to a specific unit."
             )
 
+        # Enforces "one approver per user" rule, user is either org-level or unit-level approver
+        if Approver.objects.exclude(pk=self.pk).filter(user=self.user).exists():
+            raise ValidationError("This user already has an approver scope assigned.")
+
     class Meta:
         verbose_name = "Approver"
-        verbose_name_plural = "Approves"
+        verbose_name_plural = "Approvers"

--- a/backend/api/models.py
+++ b/backend/api/models.py
@@ -90,3 +90,21 @@ class Approver(models.Model):
     class Meta:
         verbose_name = "Approver"
         verbose_name_plural = "Approvers"
+
+
+class Delegation(models.Model):
+    approver = models.ForeignKey(
+        CustomUser, on_delete=models.CASCADE, related_name="delegator"
+    )
+    delegate_to = models.ForeignKey(
+        CustomUser, on_delete=models.CASCADE, related_name="delegatee"
+    )
+    start_date = models.DateField()
+    end_date = models.DateField()
+
+    def __str__(self):
+        return f"{self.approver} delegated to {self.delegate_to} from {self.start_date} to {self.end_date}."
+
+    class Meta:
+        verbose_name = "Delegator"
+        verbose_name_plural = "Delegators"

--- a/backend/api/serializers.py
+++ b/backend/api/serializers.py
@@ -1,5 +1,5 @@
 from rest_framework import serializers
-from .models import CustomUser, Form, Unit
+from .models import CustomUser, Form, Unit, Approver
 
 
 class FormSerializer(serializers.ModelSerializer):
@@ -16,6 +16,12 @@ class UnitSerializer(serializers.ModelSerializer):
     class Meta:
         model = Unit
         fields = ["id", "name", "parent"]
+
+
+class ApproverSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Approver
+        fields = ["id", "user", "scope", "unit"]
 
 
 class UserSerializer(serializers.ModelSerializer):

--- a/backend/api/serializers.py
+++ b/backend/api/serializers.py
@@ -1,5 +1,5 @@
 from rest_framework import serializers
-from .models import CustomUser, Form, Unit, Approver, Delegation
+from .models import CustomUser, Form, Unit, Approver, Delegation, Workflow, WorkflowStep
 
 
 class FormSerializer(serializers.ModelSerializer):
@@ -116,3 +116,24 @@ class UserSerializer(serializers.ModelSerializer):
             serializer.save()
 
         return user
+
+
+class WorkflowStepSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = WorkflowStep
+        fields = [
+            "id",
+            "step_number",
+            "role_required",
+            "approver_unit",
+            "is_optional",
+            "approvals_required",
+        ]
+
+
+class WorkflowSerializer(serializers.ModelSerializer):
+    steps = WorkflowStepSerializer(many=True, read_only=True)
+
+    class Meta:
+        model = Workflow
+        fields = ["id", "name", "form_type", "origin_unit", "is_active", "steps"]

--- a/backend/api/serializers.py
+++ b/backend/api/serializers.py
@@ -1,5 +1,5 @@
 from rest_framework import serializers
-from .models import CustomUser, Form, Unit, Approver
+from .models import CustomUser, Form, Unit, Approver, Delegation
 
 
 class FormSerializer(serializers.ModelSerializer):
@@ -47,6 +47,15 @@ class ApproverSerializer(serializers.ModelSerializer):
             )
 
         return data
+
+
+class DelegationSerializer(serializers.ModelSerializer):
+    approver = serializers.PrimaryKeyRelatedField(queryset=CustomUser.objects.all())
+    delegate_to = serializers.PrimaryKeyRelatedField(queryset=CustomUser.objects.all())
+
+    class Meta:
+        model = Delegation
+        fields = ["approver", "delegate_to", "start_date", "end_date"]
 
 
 class UserSerializer(serializers.ModelSerializer):

--- a/backend/api/urls.py
+++ b/backend/api/urls.py
@@ -18,6 +18,7 @@ from .views import (
 router = DefaultRouter()
 router.register(r"forms", views.FormViewSet, basename="form")
 router.register(r"approvers", views.ApproverViewSet, basename="approver")
+router.register(r"delegations", views.DelegationViewSet, basename="delegation")
 
 urlpatterns = [
     path("users/", UserListView.as_view(), name="user-list"),

--- a/backend/api/urls.py
+++ b/backend/api/urls.py
@@ -2,25 +2,34 @@ from django.urls import path, include
 from rest_framework.routers import DefaultRouter
 from . import views
 from .views import (
-    UserListView, UserDetailView, LoginView, 
-    MSAuthView, MSAuthCallbackView,
-    FormViewSet, UserFormsView, 
-    FormSubmitView, FormApproveView, FormRejectView
+    UserListView,
+    UserDetailView,
+    LoginView,
+    MSAuthView,
+    MSAuthCallbackView,
+    FormViewSet,
+    UserFormsView,
+    FormSubmitView,
+    FormApproveView,
+    FormRejectView,
+    ApproverViewSet,
 )
 
 router = DefaultRouter()
-router.register(r'forms', views.FormViewSet, basename='form')
+router.register(r"forms", views.FormViewSet, basename="form")
+router.register(r"approvers", views.ApproverViewSet, basename="approver")
 
 urlpatterns = [
-    path('users/', UserListView.as_view(), name='user-list'),
-    path('users/<int:pk>/', UserDetailView.as_view(), name='user-detail'),
-    path('login/', LoginView.as_view(), name='login'),
-    path('ms-auth/', MSAuthView.as_view(), name='ms-auth'),
-    path('ms-auth/callback/', MSAuthCallbackView.as_view(), name='ms-auth-callback'),
-
-    path('', include(router.urls)),
-    path('users/<int:user_id>/forms/', UserFormsView.as_view(), name='user-forms'),
-    path('forms/<int:form_id>/submit/', FormSubmitView.as_view(), name='form-submit'),
-    path('forms/<int:form_id>/approve/', FormApproveView.as_view(), name='form-approve'),
-    path('forms/<int:form_id>/reject/', FormRejectView.as_view(), name='form-reject'),
+    path("users/", UserListView.as_view(), name="user-list"),
+    path("users/<int:pk>/", UserDetailView.as_view(), name="user-detail"),
+    path("login/", LoginView.as_view(), name="login"),
+    path("ms-auth/", MSAuthView.as_view(), name="ms-auth"),
+    path("ms-auth/callback/", MSAuthCallbackView.as_view(), name="ms-auth-callback"),
+    path("", include(router.urls)),
+    path("users/<int:user_id>/forms/", UserFormsView.as_view(), name="user-forms"),
+    path("forms/<int:form_id>/submit/", FormSubmitView.as_view(), name="form-submit"),
+    path(
+        "forms/<int:form_id>/approve/", FormApproveView.as_view(), name="form-approve"
+    ),
+    path("forms/<int:form_id>/reject/", FormRejectView.as_view(), name="form-reject"),
 ]

--- a/backend/api/utils.py
+++ b/backend/api/utils.py
@@ -1,0 +1,97 @@
+from .models import (
+    CustomUser,
+    Approver,
+    Delegation,
+    Workflow,
+    FormApprovalStep,
+)
+from django.utils import timezone
+from django.core.exceptions import ValidationError
+
+
+# Logic to check for approvers
+def can_approve(user, form):
+    # Check if the user is the approver or has a delegation
+    if form.approver == user:
+        return True
+
+    # Check if the original approver delegated to this user
+    return Delegation.objects.filter(
+        delegate_to=user,
+        start_date__lte=timezone.now().date(),
+        end_date__gte=timezone.now().date(),
+    ).exists()
+
+
+def has_already_approved(user, form):
+    approval_ids = form.data.get("admin_approvals", [])
+    original_approver_id = str(form.approver.id)
+
+    # Check if the original approver or any of their delegates has approved
+    delegate_ids = Delegation.objects.filter(
+        approver=form.approver,
+        start_date__lte=timezone.now().date(),
+        end_date__gte=timezone.now().date(),
+    ).values_list("delegate_to_id", flat=True)
+
+    ids_to_check = [original_approver_id] + [str(uid) for uid in delegate_ids]
+
+    return any(approver_id in approval_ids for approver_id in ids_to_check)
+
+
+# Logic to build approval chain
+def get_actual_approver(user):
+    today = timezone.now().date()
+    delegation = Delegation.objects.filter(
+        delegate_to=user, start_date__lte=today, end_date__gte=today
+    ).first()
+    return delegation.approver if delegation else user
+
+
+def get_approvers_for_step(step):
+    if step.approver_unit:
+        approvers = Approver.objects.filter(
+            unit=step.approver_unit, user__role=step.role_required
+        )
+    else:
+        approvers = Approver.objects.filter(scope="org", user__role=step.role_required)
+        return [get_actual_approver(a.user) for a in approvers]
+
+
+def initialize_approval_steps(form):
+    workflow = Workflow.objects.filter(
+        form_type=form.type, origin_unit=form.user.unit, is_active=True
+    ).first()
+
+    if not workflow:
+        return None
+
+    for step in workflow.steps.all():
+        approver = CustomUser.objects.filter(
+            role=step.role_required, unit=step.approver_unit
+        ).first()
+        if approver:
+            FormApprovalStep.objects.create(
+                form=form,
+                step_number=step.step_number,
+                approver=approver,
+            )
+    return True
+
+
+def build_approval_queue(form):
+    try:
+        workflow = Workflow.objects.get(
+            form_type=form.type, origin_unit=form.user.unit, is_active=True
+        )
+    except Workflow.DoesNotExist:
+        raise ValidationError(f"No active workflow found for form type '{form.type}'.")
+
+    steps = workflow.steps.order_by("step_number")
+    for step in steps:
+        approvers = get_approvers_for_step(step)
+        for approver in approvers[: step.approvals_required]:
+            FormApprovalStep.objects.create(
+                form=form, step_number=step.step_number, approver=approver
+            )
+    return True

--- a/backend/api/views.py
+++ b/backend/api/views.py
@@ -1,8 +1,8 @@
-from rest_framework import generics, status, viewsets
+from rest_framework import generics, status, viewsets, permissions
 from rest_framework.response import Response
 from rest_framework.permissions import IsAdminUser, AllowAny, IsAuthenticated
-from .models import CustomUser, Form
-from .serializers import UserSerializer, FormSerializer
+from .models import CustomUser, Form, Approver
+from .serializers import UserSerializer, FormSerializer, ApproverSerializer
 from rest_framework.views import APIView
 from django.contrib.auth import authenticate, login
 from django.conf import settings
@@ -11,99 +11,121 @@ from django.http import JsonResponse
 from django.shortcuts import get_object_or_404
 import datetime
 
+
+class IsAdminOrReadOnly(permissions.BasePermission):
+    def has_permission(self, request, view):
+        # Allow GET, HEAD, OPTIONS for anyone authenticated
+        if request.method in permissions.SAFE_METHODS:
+            return request.user and request.user.is_authenticated
+
+        # Only allow write if the user is admin
+        return request.user and request.user.role == "admin"
+
+
 class MSAuthView(APIView):
     permission_classes = [AllowAny]
 
     def get(self, request):
         msal_app = msal.ConfidentialClientApplication(
-            settings.AZURE_AD['CLIENT_ID'],
+            settings.AZURE_AD["CLIENT_ID"],
             authority=f"https://login.microsoftonline.com/{settings.AZURE_AD['TENANT_ID']}/",
-            client_credential=settings.AZURE_AD['CLIENT_SECRET'],
+            client_credential=settings.AZURE_AD["CLIENT_SECRET"],
         )
-        
+
         auth_url = msal_app.get_authorization_request_url(
-            scopes=settings.AZURE_AD['SCOPES'],
-            redirect_uri=settings.AZURE_AD['REDIRECT_URI'],
-            state="12345"  # Add proper state handling
+            scopes=settings.AZURE_AD["SCOPES"],
+            redirect_uri=settings.AZURE_AD["REDIRECT_URI"],
+            state="12345",  # Add proper state handling
         )
-        
+
         return JsonResponse({"auth_url": auth_url})
+
 
 class MSAuthCallbackView(APIView):
     permission_classes = [AllowAny]
 
     def post(self, request):
-        code = request.data.get('code')
-        selected_role = request.data.get('role')
-        
+        code = request.data.get("code")
+        selected_role = request.data.get("role")
+
         if not code:
-            return Response({"error": "No code provided"}, status=status.HTTP_400_BAD_REQUEST)
-        
+            return Response(
+                {"error": "No code provided"}, status=status.HTTP_400_BAD_REQUEST
+            )
+
         msal_app = msal.ConfidentialClientApplication(
-            settings.AZURE_AD['CLIENT_ID'],
+            settings.AZURE_AD["CLIENT_ID"],
             authority=f"https://login.microsoftonline.com/{settings.AZURE_AD['TENANT_ID']}/",
-            client_credential=settings.AZURE_AD['CLIENT_SECRET'],
+            client_credential=settings.AZURE_AD["CLIENT_SECRET"],
         )
-        
+
         result = msal_app.acquire_token_by_authorization_code(
             code,
-            scopes=settings.AZURE_AD['SCOPES'],
-            redirect_uri=settings.AZURE_AD['REDIRECT_URI']
+            scopes=settings.AZURE_AD["SCOPES"],
+            redirect_uri=settings.AZURE_AD["REDIRECT_URI"],
         )
-        
+
         if "error" in result:
-            return Response({"error": result.get("error_description")}, 
-                          status=status.HTTP_400_BAD_REQUEST)
+            return Response(
+                {"error": result.get("error_description")},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
 
         # Get user info from Microsoft Graph
-        access_token = result['access_token']
+        access_token = result["access_token"]
         graph_data = self.get_user_info(access_token)
-        
+
         if not graph_data:
-            return Response({"error": "Failed to get user info"}, 
-                          status=status.HTTP_400_BAD_REQUEST)
+            return Response(
+                {"error": "Failed to get user info"}, status=status.HTTP_400_BAD_REQUEST
+            )
 
         # Create or update user
         user, is_new_user = self.get_or_create_user(graph_data)
-        
+
         # If it's a new user and role is provided, set it
         if is_new_user and selected_role:
             user.role = selected_role
-            user.status = 'active'
+            user.status = "active"
             user.save()
 
         if selected_role:
             user.role = selected_role
-            user.status = 'active'
+            user.status = "active"
             user.save()
-        
+
         if user.status == "deactivated":
-            return Response({'error': 'deactivated'}, status=status.HTTP_401_UNAUTHORIZED)
-        
+            return Response(
+                {"error": "deactivated"}, status=status.HTTP_401_UNAUTHORIZED
+            )
+
         login(request, user)
         serializer = UserSerializer(user)
-        
-        return Response({
-            'user': serializer.data,
-            'message': 'Login successful',
-            'is_new_user': is_new_user
-        })
+
+        return Response(
+            {
+                "user": serializer.data,
+                "message": "Login successful",
+                "is_new_user": is_new_user,
+            }
+        )
 
     def get_user_info(self, access_token):
         import requests
-        graph_url = 'https://graph.microsoft.com/v1.0/me'
-        headers = {'Authorization': f'Bearer {access_token}'}
+
+        graph_url = "https://graph.microsoft.com/v1.0/me"
+        headers = {"Authorization": f"Bearer {access_token}"}
         response = requests.get(graph_url, headers=headers)
         return response.json() if response.status_code == 200 else None
 
     def get_or_create_user(self, graph_data):
-        email = graph_data.get('mail') or graph_data.get('userPrincipalName')
-        
+        email = graph_data.get("mail") or graph_data.get("userPrincipalName")
+
         try:
             user = CustomUser.objects.get(email=email)
             # Update existing user's info from Microsoft
-            user.first_name = graph_data.get('givenName', user.first_name)
-            user.last_name = graph_data.get('surname', user.last_name)
+            user.first_name = graph_data.get("givenName", user.first_name)
+            user.last_name = graph_data.get("surname", user.last_name)
             user.save()
             return user, False  # User exists
         except CustomUser.DoesNotExist:
@@ -111,260 +133,274 @@ class MSAuthCallbackView(APIView):
             user = CustomUser.objects.create(
                 email=email,
                 username=email,
-                first_name=graph_data.get('givenName', ''),
-                last_name=graph_data.get('surname', ''),
-                status='pending',  # New users start as pending
-                role='basicuser'  # Default role
+                first_name=graph_data.get("givenName", ""),
+                last_name=graph_data.get("surname", ""),
+                status="pending",  # New users start as pending
+                role="basicuser",  # Default role
             )
             return user, True  # New user
+
 
 class UserListView(generics.ListCreateAPIView):
     queryset = CustomUser.objects.all()
     serializer_class = UserSerializer
-    permission_classes = [AllowAny]  # [IsAdminUser] use this in prod, just no permission rn for easy testing 
+    permission_classes = [
+        AllowAny
+    ]  # [IsAdminUser] use this in prod, just no permission rn for easy testing
+
 
 class UserDetailView(generics.RetrieveUpdateDestroyAPIView):
     queryset = CustomUser.objects.all()
     serializer_class = UserSerializer
-    permission_classes = [AllowAny]  # [IsAdminUser] use this in prod, just no permission rn for easy testing 
+    permission_classes = [
+        AllowAny
+    ]  # [IsAdminUser] use this in prod, just no permission rn for easy testing
+
 
 class LoginView(APIView):
     permission_classes = [AllowAny]
 
     def post(self, request):
-        username = request.data.get('username')
-        password = request.data.get('password')
+        username = request.data.get("username")
+        password = request.data.get("password")
         user = authenticate(username=username, password=password)
         if user is not None:
             if user.status != "active":
-                return Response({'error': 'deactivated'}, status=401)
+                return Response({"error": "deactivated"}, status=401)
             login(request, user)
             serializer = UserSerializer(user)
-            return Response({
-                'user': serializer.data,
-                'message': 'Login successful'
-            })
-        return Response({
-            'error': 'Invalid credentials'
-        }, status=401)
+            return Response({"user": serializer.data, "message": "Login successful"})
+        return Response({"error": "Invalid credentials"}, status=401)
+
 
 class FormViewSet(viewsets.ModelViewSet):
     serializer_class = FormSerializer
     permission_classes = [AllowAny]
-    
+
     def get_queryset(self):
         # For list view, try to get user from query parameters
-        user_id = self.request.query_params.get('user')
+        user_id = self.request.query_params.get("user")
         if user_id:
             return Form.objects.filter(user_id=user_id)
         return Form.objects.all()
-    
+
     def perform_create(self, serializer):
         # Get user from request data
-        user_id = self.request.data.get('user')
+        user_id = self.request.data.get("user")
         if not user_id:
             raise serializer.ValidationError({"user": "This field is required"})
-            
+
         try:
             user = CustomUser.objects.get(id=user_id)
             serializer.save(user=user)
         except CustomUser.DoesNotExist:
             raise serializer.ValidationError({"user": "User does not exist"})
-    
+
     def update(self, request, *args, **kwargs):
         # Get user from request data
-        user_id = request.data.get('user')
+        user_id = request.data.get("user")
         if not user_id:
-            return Response({"user": "This field is required"}, status=status.HTTP_400_BAD_REQUEST)
-            
+            return Response(
+                {"user": "This field is required"}, status=status.HTTP_400_BAD_REQUEST
+            )
+
         # Check if the user exists
         try:
             user = CustomUser.objects.get(id=user_id)
         except CustomUser.DoesNotExist:
-            return Response({"user": "User does not exist"}, status=status.HTTP_404_NOT_FOUND)
-            
+            return Response(
+                {"user": "User does not exist"}, status=status.HTTP_404_NOT_FOUND
+            )
+
         # Get the form instance
         instance = self.get_object()
-        
+
         # Verify the form belongs to the specified user
         if instance.user.id != user.id:
-            return Response({"user": "This form does not belong to the specified user"}, status=status.HTTP_403_FORBIDDEN)
-            
+            return Response(
+                {"user": "This form does not belong to the specified user"},
+                status=status.HTTP_403_FORBIDDEN,
+            )
+
         return super().update(request, *args, **kwargs)
+
 
 class UserFormsView(generics.ListAPIView):
     serializer_class = FormSerializer
     permission_classes = [AllowAny]
-    
+
     def get_queryset(self):
-        user_id = self.kwargs.get('user_id')
+        user_id = self.kwargs.get("user_id")
         return Form.objects.filter(user_id=user_id)
+
 
 class FormSubmitView(APIView):
     permission_classes = [AllowAny]
-    
+
     def post(self, request, form_id):
         # Get user from request data
-        user_id = request.data.get('user')
+        user_id = request.data.get("user")
         if not user_id:
             return Response(
-                {"error": "user field is required"}, 
-                status=status.HTTP_400_BAD_REQUEST
+                {"error": "user field is required"}, status=status.HTTP_400_BAD_REQUEST
             )
-        
+
         try:
             # Get the user
             user = CustomUser.objects.get(id=user_id)
         except CustomUser.DoesNotExist:
             return Response(
-                {"error": "User does not exist"}, 
-                status=status.HTTP_404_NOT_FOUND
+                {"error": "User does not exist"}, status=status.HTTP_404_NOT_FOUND
             )
-        
+
         try:
             form = Form.objects.get(id=form_id)
-            
+
             if form.user.id != user.id:
                 return Response(
-                    {"error": "This form does not belong to the specified user"}, 
-                    status=status.HTTP_403_FORBIDDEN
+                    {"error": "This form does not belong to the specified user"},
+                    status=status.HTTP_403_FORBIDDEN,
                 )
-            
-            if form.status != 'draft':
+
+            if form.status != "draft":
                 return Response(
-                    {"error": "Only forms in draft status can be submitted"}, 
-                    status=status.HTTP_400_BAD_REQUEST
+                    {"error": "Only forms in draft status can be submitted"},
+                    status=status.HTTP_400_BAD_REQUEST,
                 )
-            
-            if 'required_signatures' not in form.data:
+
+            if "required_signatures" not in form.data:
                 return Response(
-                    {"error": "Form missing required_signatures field"}, 
-                    status=status.HTTP_400_BAD_REQUEST
+                    {"error": "Form missing required_signatures field"},
+                    status=status.HTTP_400_BAD_REQUEST,
                 )
-            
-            form.status = 'submitted'
+
+            form.status = "submitted"
             form.save()
-            
+
             serializer = FormSerializer(form)
             return Response(serializer.data)
-            
+
         except Form.DoesNotExist:
             return Response(
-                {"error": f"Form with ID {form_id} does not exist"}, 
-                status=status.HTTP_404_NOT_FOUND
+                {"error": f"Form with ID {form_id} does not exist"},
+                status=status.HTTP_404_NOT_FOUND,
             )
+
 
 class FormApproveView(APIView):
     permission_classes = [AllowAny]
-    
+
     def post(self, request, form_id):
         # Get admin user from request data
-        admin_id = request.data.get('user')
+        admin_id = request.data.get("user")
         if not admin_id:
             return Response(
-                {"error": "user field is required"}, 
-                status=status.HTTP_400_BAD_REQUEST
+                {"error": "user field is required"}, status=status.HTTP_400_BAD_REQUEST
             )
-        
+
         try:
             # Get the admin user
             admin_user = CustomUser.objects.get(id=admin_id)
-            
+
             # Check if user is an admin
-            if admin_user.role != 'admin':
+            if admin_user.role != "admin":
                 return Response(
-                    {"error": "Only administrators can approve forms"}, 
-                    status=status.HTTP_403_FORBIDDEN
+                    {"error": "Only administrators can approve forms"},
+                    status=status.HTTP_403_FORBIDDEN,
                 )
         except CustomUser.DoesNotExist:
             return Response(
-                {"error": "User does not exist"}, 
-                status=status.HTTP_404_NOT_FOUND
+                {"error": "User does not exist"}, status=status.HTTP_404_NOT_FOUND
             )
-        
+
         # Get the form
         form = get_object_or_404(Form, id=form_id)
-        
+
         # Check if form is in submitted status
-        if form.status != 'submitted':
+        if form.status != "submitted":
             return Response(
-                {"error": "Only submitted forms can be approved"}, 
-                status=status.HTTP_400_BAD_REQUEST
+                {"error": "Only submitted forms can be approved"},
+                status=status.HTTP_400_BAD_REQUEST,
             )
-        
+
         # Check if this admin has already approved this form
         # Store admin approvals in 'admin_approvals' list in the data field
-        if 'admin_approvals' not in form.data:
-            form.data['admin_approvals'] = []
-            
+        if "admin_approvals" not in form.data:
+            form.data["admin_approvals"] = []
+
         # If admin already approved, prevent approval
         admin_id_str = str(admin_user.id)
-        if admin_id_str in form.data['admin_approvals']:
+        if admin_id_str in form.data["admin_approvals"]:
             return Response(
-                {"error": "You have already approved this form"}, 
-                status=status.HTTP_400_BAD_REQUEST
+                {"error": "You have already approved this form"},
+                status=status.HTTP_400_BAD_REQUEST,
             )
-            
+
         # Add admin ID to approvals list
-        form.data['admin_approvals'].append(admin_id_str)
-        
+        form.data["admin_approvals"].append(admin_id_str)
+
         # Sub from required_signatures
-        if form.data['required_signatures'] > 0:
-            form.data['required_signatures'] -= 1
-            
+        if form.data["required_signatures"] > 0:
+            form.data["required_signatures"] -= 1
+
         # Check sigs
-        if form.data['required_signatures'] <= 0:
-            form.status = 'accepted'
+        if form.data["required_signatures"] <= 0:
+            form.status = "accepted"
             form.signed_on = datetime.date.today()
-            
+
         form.save()
-        
+
         serializer = FormSerializer(form)
         return Response(serializer.data)
 
+
 class FormRejectView(APIView):
     permission_classes = [AllowAny]
-    
+
     def post(self, request, form_id):
         # Get admin user from request data
-        admin_id = request.data.get('user')
+        admin_id = request.data.get("user")
         if not admin_id:
             return Response(
-                {"error": "user field is required"}, 
-                status=status.HTTP_400_BAD_REQUEST
+                {"error": "user field is required"}, status=status.HTTP_400_BAD_REQUEST
             )
-        
+
         try:
             # Get the admin user
             admin_user = CustomUser.objects.get(id=admin_id)
-            
+
             # Check if user is an admin
-            if admin_user.role != 'admin':
+            if admin_user.role != "admin":
                 return Response(
-                    {"error": "Only administrators can reject forms"}, 
-                    status=status.HTTP_403_FORBIDDEN
+                    {"error": "Only administrators can reject forms"},
+                    status=status.HTTP_403_FORBIDDEN,
                 )
         except CustomUser.DoesNotExist:
             return Response(
-                {"error": "User does not exist"}, 
-                status=status.HTTP_404_NOT_FOUND
+                {"error": "User does not exist"}, status=status.HTTP_404_NOT_FOUND
             )
-            
+
         form = get_object_or_404(Form, id=form_id)
-        
+
         # Check if form is in submitted status
-        if form.status != 'submitted':
+        if form.status != "submitted":
             return Response(
-                {"error": "Only submitted forms can be rejected"}, 
-                status=status.HTTP_400_BAD_REQUEST
+                {"error": "Only submitted forms can be rejected"},
+                status=status.HTTP_400_BAD_REQUEST,
             )
-            
+
         # Add rejection reason if we want ot
-        if 'reason' in request.data:
-            form.data['rejection_reason'] = request.data['reason']
-            
-        form.status = 'rejected'
+        if "reason" in request.data:
+            form.data["rejection_reason"] = request.data["reason"]
+
+        form.status = "rejected"
         form.save()
-        
+
         serializer = FormSerializer(form)
         return Response(serializer.data)
+
+
+class ApproverViewSet(viewsets.ModelViewSet):
+    queryset = Approver.objects.all()
+    serializer_class = ApproverSerializer
+    permission_classes = [IsAdminOrReadOnly]

--- a/backend/api/views.py
+++ b/backend/api/views.py
@@ -19,7 +19,7 @@ from django.conf import settings
 import msal
 from django.http import JsonResponse
 from django.shortcuts import get_object_or_404
-from utils import (
+from .utils import (
     can_approve,
     has_already_approved,
     get_actual_approver,


### PR DESCRIPTION
## Overview
This update introduces an Approver model to distinguish users who are permitted to approve form submissions, based on their scope of authority. Approvers can either have unit-level or organization-level scope. 

Relevant Issue - #3 

## Proposed Changes
- [x] Add `Approver` model with:
    - [x] `user`: FK to `CustomUser`
    - [x] `scope`: Either `unit` (limited to a specific unit) or `org` (can approve across all units)
    - [x] `unit`: Optional FK to `Unit`; used only when scope is `unit`
- [x] Add `ApproverSerializer` to expose approver data via the API
- [x] Add `ApproverViewSet` with restricted `POST/PUT` access where only admins can create/update approvers
- [x] Register `ApproverViewSet` with router in `urls.py`

## Notes
> The changes proposed in this PR is dependent on the approval of the previous PR (#10)
- The `Approver` model is scoped such that `scope='org'` can approve any request and `scope='unit'` can only approve requests from the assigned unit
- Permission logic for checking approver scope during approval actions will be enforced separately in form approval views
- Database migrations have not yet been applied.