### PR TITLE
Delegation of Approval Authority

### DIFF
--- a/backend/api/admin.py
+++ b/backend/api/admin.py
@@ -52,7 +52,7 @@ class WorkflowStepAdmin(admin.ModelAdmin):
         "approvals_required",
         "is_optional",
     )
-    list_filter = "workflow"
+    list_filter = ("workflow",)
     ordering = ("workflow", "step_number")
 
 

--- a/backend/api/admin.py
+++ b/backend/api/admin.py
@@ -1,6 +1,6 @@
 from django.contrib import admin
 from django.contrib.auth.admin import UserAdmin
-from .models import CustomUser, Unit, Approver
+from .models import CustomUser, Unit, Approver, Workflow, WorkflowStep
 
 
 class UnitAdmin(admin.ModelAdmin):
@@ -33,3 +33,27 @@ class ApproverAdmin(admin.ModelAdmin):
 
 
 admin.site.register(Approver, ApproverAdmin)
+
+
+class WorkflowAdmin(admin.ModelAdmin):
+    list_display = ("name", "form_type", "origin_unit", "is_active")
+    search_fields = ("name", "form_type", "origin_unit")
+
+
+admin.site.register(Workflow, WorkflowAdmin)
+
+
+class WorkflowStepAdmin(admin.ModelAdmin):
+    list_display = (
+        "workflow",
+        "step_number",
+        "role_required",
+        "approver_unit",
+        "approvals_required",
+        "is_optional",
+    )
+    list_filter = "workflow"
+    ordering = ("workflow", "step_number")
+
+
+admin.site.register(WorkflowStep, WorkflowStepAdmin)

--- a/backend/api/models.py
+++ b/backend/api/models.py
@@ -38,6 +38,9 @@ class Form(models.Model):
     # JSON field to store JSON data
     data = JSONField(default=dict)  # Use JSONField for Django >= 3.1
 
+    # Matches form with a specific approval workflow
+    type = models.CharField(max_length=100, default="general")
+
     def __str__(self):
         return f"Form {self.id} - {self.status}"
 
@@ -108,3 +111,51 @@ class Delegation(models.Model):
     class Meta:
         verbose_name = "Delegator"
         verbose_name_plural = "Delegators"
+
+
+class Workflow(models.Model):
+    form_type = models.CharField(max_length=100)
+    origin_unit = models.ForeignKey(Unit, on_delete=models.CASCADE)
+    name = models.CharField(max_length=255)
+    is_active = models.BooleanField(default=True)
+
+    class Meta:
+        verbose_name = "Workflow"
+        verbose_name_plural = "Workflows"
+
+    def __str__(self):
+        return f"{self.name} ({self.form_type} from {self.origin_unit})"
+
+
+class WorkflowStep(models.Model):
+    workflow = models.ForeignKey(
+        Workflow, related_name="steps", on_delete=models.CASCADE
+    )
+    step_number = models.PositiveIntegerField()
+    role_required = models.CharField(max_length=100)  # e.g. dept-chair
+    approver_unit = models.ForeignKey(
+        Unit, null=True, blank=True, on_delete=models.SET_NULL
+    )
+    is_optional = models.BooleanField(default=False)
+    approvals_required = models.PositiveIntegerField(
+        default=1
+    )  # number of approvals needed
+
+    class Meta:
+        ordering = ["step_number"]
+
+    def __str__(self):
+        return f"{self.workflow.name} - Step {self.step_number}"
+
+
+class FormApprovalStep(models.Model):
+    form = models.ForeignKey(
+        Form, on_delete=models.CASCADE, related_name="approval_steps"
+    )
+    step_number = models.PositiveIntegerField()
+    approver = models.ForeignKey(CustomUser, on_delete=models.CASCADE)
+    is_completed = models.BooleanField(default=False)
+    approved_on = models.DateTimeField(null=True, blank=True)
+
+    class Meta:
+        ordering = ["step_number"]

--- a/backend/api/models.py
+++ b/backend/api/models.py
@@ -90,3 +90,21 @@ class Approver(models.Model):
     class Meta:
         verbose_name = "Approver"
         verbose_name_plural = "Approvers"
+
+
+class Delegation(models.Model):
+    approver = models.ForeignKey(
+        CustomUser, on_delete=models.CASCADE, related_name="delegator"
+    )
+    delegate_to = models.ForeignKey(
+        CustomUser, on_delete=models.CASCADE, related_name="delegatee"
+    )
+    start_date = models.DateField()
+    end_date = models.DateField()
+
+    def __str__(self):
+        return f"{self.approver} delegated to {self.delegate_to} from {self.start_date} to {self.end_date}."
+
+    class Meta:
+        verbose_name = "Delegator"
+        verbose_name_plural = "Delegators"

--- a/backend/api/serializers.py
+++ b/backend/api/serializers.py
@@ -1,5 +1,5 @@
 from rest_framework import serializers
-from .models import CustomUser, Form, Unit, Approver, Delegation
+from .models import CustomUser, Form, Unit, Approver, Delegation, Workflow, WorkflowStep
 
 
 class FormSerializer(serializers.ModelSerializer):
@@ -116,3 +116,24 @@ class UserSerializer(serializers.ModelSerializer):
             serializer.save()
 
         return user
+
+
+class WorkflowStepSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = WorkflowStep
+        fields = [
+            "id",
+            "step_number",
+            "role_required",
+            "approver_unit",
+            "is_optional",
+            "approvals_required",
+        ]
+
+
+class WorkflowSerializer(serializers.ModelSerializer):
+    steps = WorkflowStepSerializer(many=True, read_only=True)
+
+    class Meta:
+        model = Workflow
+        fields = ["id", "name", "form_type", "origin_unit", "is_active", "steps"]

--- a/backend/api/serializers.py
+++ b/backend/api/serializers.py
@@ -1,5 +1,5 @@
 from rest_framework import serializers
-from .models import CustomUser, Form, Unit, Approver
+from .models import CustomUser, Form, Unit, Approver, Delegation
 
 
 class FormSerializer(serializers.ModelSerializer):
@@ -47,6 +47,15 @@ class ApproverSerializer(serializers.ModelSerializer):
             )
 
         return data
+
+
+class DelegationSerializer(serializers.ModelSerializer):
+    approver = serializers.PrimaryKeyRelatedField(queryset=CustomUser.objects.all())
+    delegate_to = serializers.PrimaryKeyRelatedField(queryset=CustomUser.objects.all())
+
+    class Meta:
+        model = Delegation
+        fields = ["approver", "delegate_to", "start_date", "end_date"]
 
 
 class UserSerializer(serializers.ModelSerializer):

--- a/backend/api/urls.py
+++ b/backend/api/urls.py
@@ -18,6 +18,7 @@ from .views import (
 router = DefaultRouter()
 router.register(r"forms", views.FormViewSet, basename="form")
 router.register(r"approvers", views.ApproverViewSet, basename="approver")
+router.register(r"delegations", views.DelegationViewSet, basename="delegation")
 
 urlpatterns = [
     path("users/", UserListView.as_view(), name="user-list"),

--- a/backend/api/utils.py
+++ b/backend/api/utils.py
@@ -1,0 +1,97 @@
+from .models import (
+    CustomUser,
+    Approver,
+    Delegation,
+    Workflow,
+    FormApprovalStep,
+)
+from django.utils import timezone
+from django.core.exceptions import ValidationError
+
+
+# Logic to check for approvers
+def can_approve(user, form):
+    # Check if the user is the approver or has a delegation
+    if form.approver == user:
+        return True
+
+    # Check if the original approver delegated to this user
+    return Delegation.objects.filter(
+        delegate_to=user,
+        start_date__lte=timezone.now().date(),
+        end_date__gte=timezone.now().date(),
+    ).exists()
+
+
+def has_already_approved(user, form):
+    approval_ids = form.data.get("admin_approvals", [])
+    original_approver_id = str(form.approver.id)
+
+    # Check if the original approver or any of their delegates has approved
+    delegate_ids = Delegation.objects.filter(
+        approver=form.approver,
+        start_date__lte=timezone.now().date(),
+        end_date__gte=timezone.now().date(),
+    ).values_list("delegate_to_id", flat=True)
+
+    ids_to_check = [original_approver_id] + [str(uid) for uid in delegate_ids]
+
+    return any(approver_id in approval_ids for approver_id in ids_to_check)
+
+
+# Logic to build approval chain
+def get_actual_approver(user):
+    today = timezone.now().date()
+    delegation = Delegation.objects.filter(
+        delegate_to=user, start_date__lte=today, end_date__gte=today
+    ).first()
+    return delegation.approver if delegation else user
+
+
+def get_approvers_for_step(step):
+    if step.approver_unit:
+        approvers = Approver.objects.filter(
+            unit=step.approver_unit, user__role=step.role_required
+        )
+    else:
+        approvers = Approver.objects.filter(scope="org", user__role=step.role_required)
+        return [get_actual_approver(a.user) for a in approvers]
+
+
+def initialize_approval_steps(form):
+    workflow = Workflow.objects.filter(
+        form_type=form.type, origin_unit=form.user.unit, is_active=True
+    ).first()
+
+    if not workflow:
+        return None
+
+    for step in workflow.steps.all():
+        approver = CustomUser.objects.filter(
+            role=step.role_required, unit=step.approver_unit
+        ).first()
+        if approver:
+            FormApprovalStep.objects.create(
+                form=form,
+                step_number=step.step_number,
+                approver=approver,
+            )
+    return True
+
+
+def build_approval_queue(form):
+    try:
+        workflow = Workflow.objects.get(
+            form_type=form.type, origin_unit=form.user.unit, is_active=True
+        )
+    except Workflow.DoesNotExist:
+        raise ValidationError(f"No active workflow found for form type '{form.type}'.")
+
+    steps = workflow.steps.order_by("step_number")
+    for step in steps:
+        approvers = get_approvers_for_step(step)
+        for approver in approvers[: step.approvals_required]:
+            FormApprovalStep.objects.create(
+                form=form, step_number=step.step_number, approver=approver
+            )
+    return True

--- a/backend/api/views.py
+++ b/backend/api/views.py
@@ -19,7 +19,7 @@ from django.conf import settings
 import msal
 from django.http import JsonResponse
 from django.shortcuts import get_object_or_404
-from utils import (
+from .utils import (
     can_approve,
     has_already_approved,
     get_actual_approver,


### PR DESCRIPTION
## Overview
This PR introduces the ability for approvers to delegate their approval authority to another user for a specific period. Delegations are tracked in a dedicated model and integrated into the existing approval flow. 

Closes #4. 

## Context
Approvers (e.g., Department heads) are sometimes unavailable for various reasons. This feature allows them to assign their approval responsibilities temporarily to another user within the same organizational scope, ensuring workflow continuity.

## Proposed Changes
- [x] Added a `Delegation` model to store approver-delegate relationships with start and end dates
- [x] Created a `DelegationViewSet` to enable creation and management of delegations via API
- [x] Updated FormApprovalViewSet logic to recognize active delegates as valid approvers
- [x] Added DelegationSerializer for safe validation and exposure via the API.
- [x] Integrated delegation handling into existing permissions and approval logic with `can_approve` and `has_already_approved` functions

## Notes
- Only users with the appropriate approver role and within the same unit/org scope are valid delegatees
- Database migrations have not yet been applied.

## Future Changes Needed
- Modified queryset filtering so delegated forms appear in the delegatee’s approval view and are hidden from the original approver during the delegation period. Related to Issue #7.